### PR TITLE
Nimble numeric matchers support some c-types

### DIFF
--- a/Sources/Nimble/Matchers/BeLessThan.swift
+++ b/Sources/Nimble/Matchers/BeLessThan.swift
@@ -33,7 +33,7 @@ public func <(lhs: Expectation<NMBComparable>, rhs: NMBComparable?) {
 extension NMBObjCMatcher {
     public class func beLessThanMatcher(_ expected: NMBComparable?) -> NMBObjCMatcher {
         return NMBObjCMatcher(canMatchNil: false) { actualExpression, failureMessage in
-            let expr = actualExpression.cast { $0 as! NMBComparable? }
+            let expr = actualExpression.cast { $0 as? NMBComparable }
             return try! beLessThan(expected).matches(expr, failureMessage: failureMessage)
         }
     }

--- a/Sources/NimbleObjectiveC/DSL.h
+++ b/Sources/NimbleObjectiveC/DSL.h
@@ -6,48 +6,215 @@
 @protocol NMBMatcher;
 
 
+NS_ASSUME_NONNULL_BEGIN
+
+
+#define NIMBLE_OVERLOADABLE __attribute__((overloadable))
 #define NIMBLE_EXPORT FOUNDATION_EXPORT
+#define NIMBLE_EXPORT_INLINE FOUNDATION_STATIC_INLINE
+
+#define NIMBLE_VALUE_OF(VAL) ({ \
+    __typeof__((VAL)) val = (VAL); \
+    [NSValue valueWithBytes:&val objCType:@encode(__typeof__((VAL)))]; \
+})
 
 #ifdef NIMBLE_DISABLE_SHORT_SYNTAX
 #define NIMBLE_SHORT(PROTO, ORIGINAL)
+#define NIMBLE_SHORT_OVERLOADED(PROTO, ORIGINAL)
 #else
 #define NIMBLE_SHORT(PROTO, ORIGINAL) FOUNDATION_STATIC_INLINE PROTO { return (ORIGINAL); }
+#define NIMBLE_SHORT_OVERLOADED(PROTO, ORIGINAL) FOUNDATION_STATIC_INLINE NIMBLE_OVERLOADABLE PROTO { return (ORIGINAL); }
 #endif
 
-NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), NSString *file, NSUInteger line);
+
+
+#define DEFINE_NMB_EXPECT_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        NMBExpectation *NMB_expect(TYPE(^actualBlock)(), NSString *file, NSUInteger line) { \
+            return NMB_expect(^id { return EXPR; }, file, line); \
+        }
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    NMBExpectation *NMB_expect(id(^actualBlock)(), NSString *file, NSUInteger line);
+
+    // overloaded dispatch for nils - expect(nil)
+    DEFINE_NMB_EXPECT_OVERLOAD(void*, nil)
+    DEFINE_NMB_EXPECT_OVERLOAD(NSRange, NIMBLE_VALUE_OF(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(long, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(unsigned long, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(int, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(unsigned int, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(float, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(double, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(long long, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(unsigned long long, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(char, @(actualBlock()))
+    DEFINE_NMB_EXPECT_OVERLOAD(unsigned char, @(actualBlock()))
+
+#undef DEFINE_NMB_EXPECT_OVERLOAD
+
+
+
 NIMBLE_EXPORT NMBExpectation *NMB_expectAction(void(^actualBlock)(), NSString *file, NSUInteger line);
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_equal(id expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> equal(id expectedValue),
-             NMB_equal(expectedValue));
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_haveCount(id expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> haveCount(id expectedValue),
-             NMB_haveCount(expectedValue));
 
-NIMBLE_EXPORT NMBObjCBeCloseToMatcher *NMB_beCloseTo(NSNumber *expectedValue);
-NIMBLE_SHORT(NMBObjCBeCloseToMatcher *beCloseTo(id expectedValue),
-             NMB_beCloseTo(expectedValue));
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> NMB_equal(TYPE expectedValue) { \
+            return NMB_equal((EXPR)); \
+        } \
+        NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> equal(TYPE expectedValue), NMB_equal(expectedValue));
+
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_equal(id expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> equal(id expectedValue) { return NMB_equal(expectedValue); }
+
+    DEFINE_OVERLOAD(NSRange, NIMBLE_VALUE_OF(expectedValue))
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(float, @(expectedValue))
+    DEFINE_OVERLOAD(double, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
+
+
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> NMB_haveCount(TYPE expectedValue) { \
+            return NMB_haveCount((EXPR)); \
+        } \
+        NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> haveCount(TYPE expectedValue), NMB_haveCount(expectedValue));
+
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_haveCount(id expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> haveCount(id expectedValue) {
+        return NMB_haveCount(expectedValue);
+    }
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
+
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        NMBObjCBeCloseToMatcher *NMB_beCloseTo(TYPE expectedValue) { \
+            return NMB_beCloseTo((NSNumber *)(EXPR)); \
+        } \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        NMBObjCBeCloseToMatcher *beCloseTo(TYPE expectedValue) { \
+            return NMB_beCloseTo(expectedValue); \
+        }
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE NMBObjCBeCloseToMatcher *NMB_beCloseTo(NSNumber *expectedValue);
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    NMBObjCBeCloseToMatcher *beCloseTo(NSNumber *expectedValue) {
+        return NMB_beCloseTo(expectedValue);
+    }
+
+    // it would be better to only overload float & double, but zero becomes ambigious
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(float, @(expectedValue))
+    DEFINE_OVERLOAD(double, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_beAnInstanceOf(Class expectedClass);
-NIMBLE_SHORT(id<NMBMatcher> beAnInstanceOf(Class expectedClass),
-             NMB_beAnInstanceOf(expectedClass));
+NIMBLE_EXPORT_INLINE id<NMBMatcher> beAnInstanceOf(Class expectedClass) {
+    return NMB_beAnInstanceOf(expectedClass);
+}
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_beAKindOf(Class expectedClass);
-NIMBLE_SHORT(id<NMBMatcher> beAKindOf(Class expectedClass),
-             NMB_beAKindOf(expectedClass));
+NIMBLE_EXPORT_INLINE id<NMBMatcher> beAKindOf(Class expectedClass) {
+    return NMB_beAKindOf(expectedClass);
+}
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_beginWith(id itemElementOrSubstring);
-NIMBLE_SHORT(id<NMBMatcher> beginWith(id itemElementOrSubstring),
-             NMB_beginWith(itemElementOrSubstring));
+NIMBLE_EXPORT_INLINE id<NMBMatcher> beginWith(id itemElementOrSubstring) {
+    return NMB_beginWith(itemElementOrSubstring);
+}
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beGreaterThan(NSNumber *expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> beGreaterThan(NSNumber *expectedValue),
-             NMB_beGreaterThan(expectedValue));
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> NMB_beGreaterThan(TYPE expectedValue) { return NMB_beGreaterThan((EXPR)); } \
+        NIMBLE_SHORT_OVERLOADED(id<NMBMatcher> beGreaterThan(TYPE expectedValue), NMB_beGreaterThan(expectedValue));
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beGreaterThanOrEqualTo(NSNumber *expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> beGreaterThanOrEqualTo(NSNumber *expectedValue),
-             NMB_beGreaterThanOrEqualTo(expectedValue));
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_beGreaterThan(NSNumber *expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> beGreaterThan(NSNumber *expectedValue) {
+        return NMB_beGreaterThan(expectedValue);
+    }
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
+
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> NMB_beGreaterThanOrEqualTo(TYPE expectedValue) { \
+            return NMB_beGreaterThanOrEqualTo((EXPR)); \
+        } \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> beGreaterThanOrEqualTo(TYPE expectedValue) { \
+            return NMB_beGreaterThanOrEqualTo(expectedValue); \
+        }
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_beGreaterThanOrEqualTo(NSNumber *expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> beGreaterThanOrEqualTo(NSNumber *expectedValue) {
+        return NMB_beGreaterThanOrEqualTo(expectedValue);
+    }
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(float, @(expectedValue))
+    DEFINE_OVERLOAD(double, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_beIdenticalTo(id expectedInstance);
 NIMBLE_SHORT(id<NMBMatcher> beIdenticalTo(id expectedInstance),
@@ -57,13 +224,71 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_be(id expectedInstance);
 NIMBLE_SHORT(id<NMBMatcher> be(id expectedInstance),
              NMB_be(expectedInstance));
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> beLessThan(NSNumber *expectedValue),
-             NMB_beLessThan(expectedValue));
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThanOrEqualTo(NSNumber *expectedValue);
-NIMBLE_SHORT(id<NMBMatcher> beLessThanOrEqualTo(NSNumber *expectedValue),
-             NMB_beLessThanOrEqualTo(expectedValue));
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> NMB_beLessThan(TYPE expectedValue) { \
+            return NMB_beLessThan((EXPR)); \
+        } \
+        NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+        id<NMBMatcher> beLessThan(TYPE expectedValue) { \
+            return NMB_beLessThan(expectedValue); \
+        }
+
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> beLessThan(NSNumber *expectedValue) {
+        return NMB_beLessThan(expectedValue);
+    }
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(float, @(expectedValue))
+    DEFINE_OVERLOAD(double, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
+
+
+#define DEFINE_OVERLOAD(TYPE, EXPR) \
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+    id<NMBMatcher> NMB_beLessThanOrEqualTo(TYPE expectedValue) { \
+        return NMB_beLessThanOrEqualTo((EXPR)); \
+    } \
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE \
+    id<NMBMatcher> beLessThanOrEqualTo(TYPE expectedValue) { \
+        return NMB_beLessThanOrEqualTo(expectedValue); \
+    }
+
+
+    NIMBLE_EXPORT NIMBLE_OVERLOADABLE
+    id<NMBMatcher> NMB_beLessThanOrEqualTo(NSNumber *expectedValue);
+
+    NIMBLE_EXPORT_INLINE NIMBLE_OVERLOADABLE
+    id<NMBMatcher> beLessThanOrEqualTo(NSNumber *expectedValue) {
+        return NMB_beLessThanOrEqualTo(expectedValue);
+    }
+
+    DEFINE_OVERLOAD(long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long, @(expectedValue))
+    DEFINE_OVERLOAD(int, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned int, @(expectedValue))
+    DEFINE_OVERLOAD(float, @(expectedValue))
+    DEFINE_OVERLOAD(double, @(expectedValue))
+    DEFINE_OVERLOAD(long long, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned long long, @(expectedValue))
+    DEFINE_OVERLOAD(char, @(expectedValue))
+    DEFINE_OVERLOAD(unsigned char, @(expectedValue))
+
+#undef DEFINE_OVERLOAD
 
 NIMBLE_EXPORT id<NMBMatcher> NMB_beTruthy(void);
 NIMBLE_SHORT(id<NMBMatcher> beTruthy(void),
@@ -133,8 +358,10 @@ NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger
 #define NMB_waitUntilTimeout NMB_waitUntilTimeoutBuilder(@(__FILE__), __LINE__)
 #define NMB_waitUntil NMB_waitUntilBuilder(@(__FILE__), __LINE__)
 
+#undef NIMBLE_VALUE_OF
+
 #ifndef NIMBLE_DISABLE_SHORT_SYNTAX
-#define expect(...) NMB_expect(^id{ return (__VA_ARGS__); }, @(__FILE__), __LINE__)
+#define expect(...) NMB_expect(^{ return (__VA_ARGS__); }, @(__FILE__), __LINE__)
 #define expectAction(BLOCK) NMB_expectAction((BLOCK), @(__FILE__), __LINE__)
 #define failWithMessage(msg) NMB_failWithMessage(msg, @(__FILE__), __LINE__)
 #define fail() failWithMessage(@"fail() always fails")
@@ -142,4 +369,7 @@ NIMBLE_EXPORT void NMB_failWithMessage(NSString *msg, NSString *file, NSUInteger
 
 #define waitUntilTimeout NMB_waitUntilTimeout
 #define waitUntil NMB_waitUntil
+
 #endif
+
+NS_ASSUME_NONNULL_END

--- a/Sources/NimbleObjectiveC/DSL.m
+++ b/Sources/NimbleObjectiveC/DSL.m
@@ -9,7 +9,11 @@ SWIFT_CLASS("_TtC6Nimble7NMBWait")
 
 @end
 
-NIMBLE_EXPORT NMBExpectation *NMB_expect(id(^actualBlock)(), NSString *file, NSUInteger line) {
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE NMBExpectation *__nonnull NMB_expect(id __nullable(^actualBlock)(), NSString *__nonnull file, NSUInteger line) {
     return [[NMBExpectation alloc] initWithActualBlock:actualBlock
                                               negative:NO
                                                   file:file
@@ -35,7 +39,7 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_beAKindOf(Class expectedClass) {
     return [NMBObjCMatcher beAKindOfMatcher:expectedClass];
 }
 
-NIMBLE_EXPORT NMBObjCBeCloseToMatcher *NMB_beCloseTo(NSNumber *expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE NMBObjCBeCloseToMatcher *NMB_beCloseTo(NSNumber *expectedValue) {
     return [NMBObjCMatcher beCloseToMatcher:expectedValue within:0.001];
 }
 
@@ -43,11 +47,11 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_beginWith(id itemElementOrSubstring) {
     return [NMBObjCMatcher beginWithMatcher:itemElementOrSubstring];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beGreaterThan(NSNumber *expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_beGreaterThan(NSNumber *expectedValue) {
     return [NMBObjCMatcher beGreaterThanMatcher:expectedValue];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beGreaterThanOrEqualTo(NSNumber *expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_beGreaterThanOrEqualTo(NSNumber *expectedValue) {
     return [NMBObjCMatcher beGreaterThanOrEqualToMatcher:expectedValue];
 }
 
@@ -59,11 +63,11 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_be(id expectedInstance) {
     return [NMBObjCMatcher beIdenticalToMatcher:expectedInstance];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_beLessThan(NSNumber *expectedValue) {
     return [NMBObjCMatcher beLessThanMatcher:expectedValue];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_beLessThanOrEqualTo(NSNumber *expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_beLessThanOrEqualTo(NSNumber *expectedValue) {
     return [NMBObjCMatcher beLessThanOrEqualToMatcher:expectedValue];
 }
 
@@ -113,11 +117,11 @@ NIMBLE_EXPORT id<NMBMatcher> NMB_endWith(id itemElementOrSubstring) {
     return [NMBObjCMatcher endWithMatcher:itemElementOrSubstring];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_equal(id expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_equal(id expectedValue) {
     return [NMBObjCMatcher equalMatcher:expectedValue];
 }
 
-NIMBLE_EXPORT id<NMBMatcher> NMB_haveCount(id expectedValue) {
+NIMBLE_EXPORT NIMBLE_OVERLOADABLE id<NMBMatcher> NMB_haveCount(id expectedValue) {
     return [NMBObjCMatcher haveCountMatcher:expectedValue];
 }
 
@@ -148,3 +152,5 @@ NIMBLE_EXPORT NMBWaitUntilBlock NMB_waitUntilBuilder(NSString *file, NSUInteger 
     [NMBWait untilFile:file line:line action:action];
   };
 }
+
+NS_ASSUME_NONNULL_END

--- a/Tests/NimbleTests/objc/ObjCBeCloseToTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeCloseToTest.m
@@ -12,6 +12,11 @@
     expect(@1.2).to(beCloseTo(@2).within(10));
     expect(@2).toNot(beCloseTo(@1));
     expect(@1.00001).toNot(beCloseTo(@1).within(0.00000001));
+
+    expect(1.2).to(beCloseTo(1.2001));
+    expect(1.2).to(beCloseTo(2).within(10));
+    expect(2).toNot(beCloseTo(1));
+    expect(1.00001).toNot(beCloseTo(1).within(0.00000001));
 }
 
 - (void)testNegativeMatches {
@@ -20,6 +25,12 @@
     });
     expectFailureMessage(@"expected to not be close to <0> (within 0.001), got <0.0001>", ^{
         expect(@(0.0001)).toNot(beCloseTo(@0));
+    });
+    expectFailureMessage(@"expected to be close to <0> (within 0.001), got <1>", ^{
+        expect(1).to(beCloseTo(0));
+    });
+    expectFailureMessage(@"expected to not be close to <0> (within 0.001), got <0.0001>", ^{
+        expect(0.0001).toNot(beCloseTo(0));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeGreaterThanOrEqualToTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeGreaterThanOrEqualToTest.m
@@ -10,6 +10,9 @@
 - (void)testPositiveMatches {
     expect(@2).to(beGreaterThanOrEqualTo(@2));
     expect(@2).toNot(beGreaterThanOrEqualTo(@3));
+    expect(2).to(beGreaterThanOrEqualTo(0));
+    expect(2).to(beGreaterThanOrEqualTo(2));
+    expect(2).toNot(beGreaterThanOrEqualTo(3));
 }
 
 - (void)testNegativeMatches {
@@ -18,6 +21,12 @@
     });
     expectFailureMessage(@"expected to not be greater than or equal to <1>, got <2>", ^{
         expect(@2).toNot(beGreaterThanOrEqualTo(@(1)));
+    });
+    expectFailureMessage(@"expected to be greater than or equal to <0>, got <-1>", ^{
+        expect(-1).to(beGreaterThanOrEqualTo(0));
+    });
+    expectFailureMessage(@"expected to not be greater than or equal to <1>, got <2>", ^{
+        expect(2).toNot(beGreaterThanOrEqualTo(1));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeGreaterThanTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeGreaterThanTest.m
@@ -10,6 +10,8 @@
 - (void)testPositiveMatches {
     expect(@2).to(beGreaterThan(@1));
     expect(@2).toNot(beGreaterThan(@2));
+    expect(@2).to(beGreaterThan(0));
+    expect(@2).toNot(beGreaterThan(2));
 }
 
 - (void)testNegativeMatches {
@@ -18,6 +20,12 @@
     });
     expectFailureMessage(@"expected to not be greater than <1>, got <0>", ^{
         expect(@0).toNot(beGreaterThan(@(1)));
+    });
+    expectFailureMessage(@"expected to be greater than <0>, got <-1>", ^{
+        expect(-1).to(beGreaterThan(0));
+    });
+    expectFailureMessage(@"expected to not be greater than <1>, got <0>", ^{
+        expect(0).toNot(beGreaterThan(1));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeIdenticalToTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeIdenticalToTest.m
@@ -25,9 +25,12 @@
 
 - (void)testNilMatches {
     NSNull *obj = [NSNull null];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     expectNilFailureMessage(@"expected to be identical to nil, got nil", ^{
         expect(nil).to(beIdenticalTo(nil));
     });
+#pragma clang diagnostic pop
     expectNilFailureMessage(([NSString stringWithFormat:@"expected to not be identical to <%p>, got nil", obj]), ^{
         expect(nil).toNot(beIdenticalTo(obj));
     });
@@ -51,9 +54,12 @@
 
 - (void)testAliasNilMatches {
     NSNull *obj = [NSNull null];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     expectNilFailureMessage(@"expected to be identical to nil, got nil", ^{
         expect(nil).to(be(nil));
     });
+#pragma clang diagnostic pop
     expectNilFailureMessage(([NSString stringWithFormat:@"expected to not be identical to <%p>, got nil", obj]), ^{
         expect(nil).toNot(be(obj));
     });

--- a/Tests/NimbleTests/objc/ObjCBeLessThanOrEqualToTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeLessThanOrEqualToTest.m
@@ -10,6 +10,9 @@
 - (void)testPositiveMatches {
     expect(@2).to(beLessThanOrEqualTo(@2));
     expect(@2).toNot(beLessThanOrEqualTo(@1));
+    expect(2).to(beLessThanOrEqualTo(2));
+    expect(2).toNot(beLessThanOrEqualTo(1));
+    expect(2).toNot(beLessThanOrEqualTo(0));
 }
 
 - (void)testNegativeMatches {
@@ -18,6 +21,13 @@
     });
     expectFailureMessage(@"expected to not be less than or equal to <1>, got <1>", ^{
         expect(@1).toNot(beLessThanOrEqualTo(@1));
+    });
+
+    expectFailureMessage(@"expected to be less than or equal to <1>, got <2>", ^{
+        expect(2).to(beLessThanOrEqualTo(1));
+    });
+    expectFailureMessage(@"expected to not be less than or equal to <1>, got <1>", ^{
+        expect(1).toNot(beLessThanOrEqualTo(1));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCBeLessThanTest.m
+++ b/Tests/NimbleTests/objc/ObjCBeLessThanTest.m
@@ -10,6 +10,9 @@
 - (void)testPositiveMatches {
     expect(@2).to(beLessThan(@3));
     expect(@2).toNot(beLessThan(@2));
+    expect(2).to(beLessThan(3));
+    expect(2).toNot(beLessThan(2));
+    expect(2).toNot(beLessThan(0));
 }
 
 - (void)testNegativeMatches {
@@ -18,6 +21,12 @@
     });
     expectFailureMessage(@"expected to not be less than <1>, got <0>", ^{
         expect(@0).toNot(beLessThan(@1));
+    });
+    expectFailureMessage(@"expected to be less than <0>, got <-1>", ^{
+        expect(-1).to(beLessThan(0));
+    });
+    expectFailureMessage(@"expected to not be less than <1>, got <0>", ^{
+        expect(0).toNot(beLessThan(1));
     });
 }
 

--- a/Tests/NimbleTests/objc/ObjCEqualTest.m
+++ b/Tests/NimbleTests/objc/ObjCEqualTest.m
@@ -12,6 +12,29 @@
     expect(@1).toNot(equal(@2));
     expect(@1).notTo(equal(@2));
     expect(@"hello").to(equal(@"hello"));
+    expect(NSMakeRange(0, 10)).to(equal(NSMakeRange(0, 10)));
+    expect(NSMakeRange(0, 10)).toNot(equal(NSMakeRange(0, 5)));
+    expect((NSInteger)1).to(equal((NSInteger)1));
+    expect((NSInteger)1).toNot(equal((NSInteger)2));
+    expect((NSUInteger)1).to(equal((NSUInteger)1));
+    expect((NSUInteger)1).toNot(equal((NSUInteger)2));
+    expect(1).to(equal(1));
+    expect(1).toNot(equal(2));
+    expect(1.0).to(equal(1.0)); // Note: not recommended, use beCloseTo() instead
+    expect(1.0).toNot(equal(2.0)); // Note: not recommended, use beCloseTo() instead
+    expect((float)1.0).to(equal((float)1.0));  // Note: not recommended, use beCloseTo() instead
+    expect((float)1.0).toNot(equal((float)2.0));  // Note: not recommended, use beCloseTo() instead
+    expect((double)1.0).to(equal((double)1.0));  // Note: not recommended, use beCloseTo() instead
+    expect((double)1.0).toNot(equal((double)2.0));  // Note: not recommended, use beCloseTo() instead
+    expect((long long)1).to(equal((long long)1));
+    expect((long long)1).toNot(equal((long long)2));
+    expect((unsigned long long)1).to(equal((unsigned long long)1));
+    expect((unsigned long long)1).toNot(equal((unsigned long long)2));
+}
+
+- (void)testNimbleCurrentlyBoxesNumbersWhichAllowsImplicitTypeConversions {
+    expect(1).to(equal(1.0));
+    expect((long long)1).to(equal((unsigned long long)1));
 }
 
 - (void)testNegativeMatches {
@@ -21,15 +44,46 @@
     expectFailureMessage(@"expected to not equal <1>, got <1>", ^{
         expect(@1).toNot(equal(@1));
     });
+    expectFailureMessage(@"expected to equal <NSRange: {0, 5}>, got <NSRange: {0, 10}>", ^{
+        expect(NSMakeRange(0, 10)).to(equal(NSMakeRange(0, 5)));
+    });
+
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((NSInteger)1).to(equal((NSInteger)2));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((NSUInteger)1).to(equal((NSUInteger)2));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect(1).to(equal(2));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect(1.0).to(equal(2.0));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((float)1.0).to(equal((float)2.0));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((double)1.0).to(equal((double)2.0));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((long long)1.0).to(equal((long long)2.0));
+    });
+    expectFailureMessage(@"expected to equal <2>, got <1>", ^{
+        expect((unsigned long long)1.0).to(equal((unsigned long long)2.0));
+    });
 }
 
 - (void)testNilMatches {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     expectNilFailureMessage(@"expected to equal <nil>, got <nil>", ^{
         expect(nil).to(equal(nil));
     });
     expectNilFailureMessage(@"expected to not equal <nil>, got <nil>", ^{
         expect(nil).toNot(equal(nil));
     });
+#pragma clang diagnostic pop
 }
 
 @end

--- a/Tests/NimbleTests/objc/ObjCHaveCount.m
+++ b/Tests/NimbleTests/objc/ObjCHaveCount.m
@@ -14,6 +14,12 @@
     expect(@[]).to(haveCount(@0));
     expect(@[@1]).notTo(haveCount(@0));
 
+    expect(@[@1, @2, @3]).to(haveCount(3));
+    expect(@[@1, @2, @3]).notTo(haveCount(1));
+
+    expect(@[]).to(haveCount(0));
+    expect(@[@1]).notTo(haveCount(0));
+
     expectFailureMessage(@"expected to have NSArray with count 1, got 3\nActual Value: (1, 2, 3)", ^{
         expect(@[@1, @2, @3]).to(haveCount(@1));
     });
@@ -22,11 +28,21 @@
         expect(@[@1, @2, @3]).notTo(haveCount(@3));
     });
 
+    expectFailureMessage(@"expected to have NSArray with count 1, got 3\nActual Value: (1, 2, 3)", ^{
+        expect(@[@1, @2, @3]).to(haveCount(1));
+    });
+
+    expectFailureMessage(@"expected to not have NSArray with count 3, got 3\nActual Value: (1, 2, 3)", ^{
+        expect(@[@1, @2, @3]).notTo(haveCount(3));
+    });
 }
 
 - (void)testHaveCountForNSDictionary {
     expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(@3));
     expect(@{@"1":@1, @"2":@2, @"3":@3}).notTo(haveCount(@1));
+
+    expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(3));
+    expect(@{@"1":@1, @"2":@2, @"3":@3}).notTo(haveCount(1));
 
     expectFailureMessage(@"expected to have NSDictionary with count 1, got 3\nActual Value: {1 = 1;2 = 2;3 = 3;}", ^{
         expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(@1));
@@ -34,6 +50,14 @@
 
     expectFailureMessage(@"expected to not have NSDictionary with count 3, got 3\nActual Value: {1 = 1;2 = 2;3 = 3;}", ^{
         expect(@{@"1":@1, @"2":@2, @"3":@3}).notTo(haveCount(@3));
+    });
+
+    expectFailureMessage(@"expected to have NSDictionary with count 1, got 3\nActual Value: {1 = 1;2 = 2;3 = 3;}", ^{
+        expect(@{@"1":@1, @"2":@2, @"3":@3}).to(haveCount(1));
+    });
+
+    expectFailureMessage(@"expected to not have NSDictionary with count 3, got 3\nActual Value: {1 = 1;2 = 2;3 = 3;}", ^{
+        expect(@{@"1":@1, @"2":@2, @"3":@3}).notTo(haveCount(3));
     });
 }
 
@@ -46,6 +70,9 @@
     expect(table).to(haveCount(@3));
     expect(table).notTo(haveCount(@1));
 
+    expect(table).to(haveCount(3));
+    expect(table).notTo(haveCount(1));
+
     NSString *msg = [NSString stringWithFormat:
                      @"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 1, got 3\nActual Value: %@",
                      [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
@@ -53,12 +80,26 @@
         expect(table).to(haveCount(@1));
     });
 
-
     msg = [NSString stringWithFormat:
            @"expected to not have NSHashTable {[2] 2[12] 1[13] 3}with count 3, got 3\nActual Value: %@",
            [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
     expectFailureMessage(msg, ^{
         expect(table).notTo(haveCount(@3));
+    });
+
+
+    msg = [NSString stringWithFormat:
+           @"expected to have NSHashTable {[2] 2[12] 1[13] 3}with count 1, got 3\nActual Value: %@",
+           [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
+    expectFailureMessage(msg, ^{
+        expect(table).to(haveCount(1));
+    });
+
+    msg = [NSString stringWithFormat:
+           @"expected to not have NSHashTable {[2] 2[12] 1[13] 3}with count 3, got 3\nActual Value: %@",
+           [table.description stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
+    expectFailureMessage(msg, ^{
+        expect(table).notTo(haveCount(3));
     });
 }
 
@@ -67,6 +108,8 @@
 
     expect(set).to(haveCount(@3));
     expect(set).notTo(haveCount(@1));
+    expect(set).to(haveCount(3));
+    expect(set).notTo(haveCount(1));
 
     expectFailureMessage(@"expected to have NSSet with count 1, got 3\nActual Value: {(3,1,2)}", ^{
         expect(set).to(haveCount(@1));
@@ -75,6 +118,14 @@
     expectFailureMessage(@"expected to not have NSSet with count 3, got 3\nActual Value: {(3,1,2)}", ^{
         expect(set).notTo(haveCount(@3));
     });
+
+    expectFailureMessage(@"expected to have NSSet with count 1, got 3\nActual Value: {(3,1,2)}", ^{
+        expect(set).to(haveCount(1));
+    });
+
+    expectFailureMessage(@"expected to not have NSSet with count 3, got 3\nActual Value: {(3,1,2)}", ^{
+        expect(set).notTo(haveCount(3));
+    });
 }
 
 - (void)testHaveCountForNSIndexSet {
@@ -82,6 +133,8 @@
 
     expect(set).to(haveCount(@3));
     expect(set).notTo(haveCount(@1));
+    expect(set).to(haveCount(3));
+    expect(set).notTo(haveCount(1));
 
     expectFailureMessage(@"expected to have NSIndexSet with count 1, got 3\nActual Value: (1, 2, 3)", ^{
         expect(set).to(haveCount(@1));
@@ -89,6 +142,14 @@
 
     expectFailureMessage(@"expected to not have NSIndexSet with count 3, got 3\nActual Value: (1, 2, 3)", ^{
         expect(set).notTo(haveCount(@3));
+    });
+
+    expectFailureMessage(@"expected to have NSIndexSet with count 1, got 3\nActual Value: (1, 2, 3)", ^{
+        expect(set).to(haveCount(1));
+    });
+
+    expectFailureMessage(@"expected to not have NSIndexSet with count 3, got 3\nActual Value: (1, 2, 3)", ^{
+        expect(set).notTo(haveCount(3));
     });
 }
 
@@ -99,6 +160,14 @@
 
     expectFailureMessage(@"expected to get type of NSArray, NSSet, NSDictionary, or NSHashTable, got __NSCFNumber", ^{
         expect(@1).to(haveCount(@6));
+    });
+
+    expectFailureMessage(@"expected to get type of NSArray, NSSet, NSDictionary, or NSHashTable, got __NSCFConstantString", ^{
+        expect(@"string").to(haveCount(6));
+    });
+
+    expectFailureMessage(@"expected to get type of NSArray, NSSet, NSDictionary, or NSHashTable, got __NSCFNumber", ^{
+        expect(@1).to(haveCount(6));
     });
 }
 


### PR DESCRIPTION
- Add (non-)nullability for Nimble's headers
- Convert assertion to optional

Example:

``` objc
expect(timesTapped).to(equal(2));
expect(temperatureInFahrenheit).to(beCloseTo(98.7));
expect(timesTapped).to(beLessThan(100));
expect(activeRequests).to(haveCount(2));
```

Needs Documentation
